### PR TITLE
add: レイアウトのコンポーネント化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       },
@@ -14884,6 +14885,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.1.tgz",
+      "integrity": "sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.1.tgz",
+      "integrity": "sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -15789,6 +15837,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,58 +1,16 @@
 import React from 'react';
-import './index.css'; // アニメーション用CSSを忘れずに
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import EventList from './pages/EventList';
 
 function App() {
-  // バブルをランダムに10〜13個生成
-  const bubbleCount = Math.floor(Math.random() * 4) + 10; // 10〜13
-  const bubbles = Array.from({ length: bubbleCount }).map((_, i) => {
-    const size = Math.floor(Math.random() * 60) + 40; // 40〜100px
-    const top = Math.floor(Math.random() * 100); // 0〜100%
-    const left = Math.floor(Math.random() * 100); // 0〜100%
-    const delay = Math.random() * 5; // 0〜5秒
-
-    return (
-      <div
-        key={i}
-        className="bubble"
-        style={{
-          width: `${size}px`,
-          height: `${size}px`,
-          top: `${top}%`,
-          left: `${left}%`,
-          animationDelay: `${delay}s`,
-        }}
-      />
-    );
-  });
-
   return (
-    <div className="min-h-screen bg-gradient-to-b from-green-100 via-green-50 to-white relative overflow-hidden text-center p-4 animate-fade-in">
-      {/* 背景バブル */}
-      {bubbles}
-
-      {/* ヘッダー */}
-      <header className="relative z-10 flex justify-between items-center p-4 bg-green-100 shadow-md rounded-lg">
-        <h1 className="text-2xl font-bold text-green-700">🌿 LocalHub</h1>
-        <nav className="space-x-4">
-          <button className="bg-green-600 text-white px-4 py-2 rounded-lg shadow hover:bg-green-700 transition">
-            イベントを探す
-          </button>
-          <button className="bg-white text-green-700 border border-green-600 px-4 py-2 rounded-lg shadow hover:bg-green-50 transition">
-            ログイン
-          </button>
-        </nav>
-      </header>
-
-      {/* メイン */}
-      <main className="relative z-10 flex-grow flex flex-col items-center justify-center h-[calc(100vh-120px)]">
-        <h2 className="text-4xl md:text-6xl font-bold text-green-700 mb-4">
-          ようこそ、LocalHubへ！
-        </h2>
-        <p className="text-lg md:text-xl text-green-600">
-          地域のイベントを、みんなで見つけて・広げよう
-        </p>
-      </main>
-    </div>
+    <Router>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/events" element={<EventList />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+function Header() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // 現在のパスがトップページなら true
+  const isHome = location.pathname === '/';
+
+  return (
+    <header className="relative z-10 flex justify-between items-center p-4 bg-green-100 shadow-md rounded-lg">
+      {/* ロゴ */}
+      <h1 className="text-2xl font-bold text-green-700">🌿 LocalHub</h1>
+
+      {/* ナビゲーションボタン */}
+      <nav className="space-x-4 flex items-center">
+        {/* トップページにいる時だけ「イベントを探す」ボタンを表示 */}
+        {isHome && (
+          <button
+            onClick={() => navigate('/events')}
+            className="bg-green-600 text-white px-4 py-2 rounded-lg shadow hover:bg-green-700 transition"
+          >
+            イベントを探す
+          </button>
+        )}
+
+        {/* トップ以外では「ホームに戻る」ボタンを表示 */}
+        {!isHome && (
+          <button
+            onClick={() => navigate('/')}
+            className="bg-green-300 text-green-900 px-4 py-2 rounded-lg shadow hover:bg-green-400 transition"
+          >
+            ホームに戻る
+          </button>
+        )}
+
+        {/* ログインボタン（全ページ共通表示） */}
+        <button className="bg-white text-green-700 border border-green-600 px-4 py-2 rounded-lg shadow hover:bg-green-50 transition">
+          ログイン
+        </button>
+      </nav>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import Header from './Header';
+import { useLocation } from 'react-router-dom';
+import '../index.css';
+
+function Layout({ children }) {
+  const location = useLocation();
+
+  // ページごとにバブルの生成（トップ以外も表示）
+  const bubbleCount = Math.floor(Math.random() * 4) + 10;
+  const bubbles = Array.from({ length: bubbleCount }).map((_, i) => {
+    const size = Math.floor(Math.random() * 60) + 40;
+    const top = Math.floor(Math.random() * 100);
+    const left = Math.floor(Math.random() * 100);
+    const delay = Math.random() * 5;
+
+    return (
+      <div
+        key={i}
+        className="bubble"
+        style={{
+          width: `${size}px`,
+          height: `${size}px`,
+          top: `${top}%`,
+          left: `${left}%`,
+          animationDelay: `${delay}s`,
+        }}
+      />
+    );
+  });
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-green-100 via-green-50 to-white relative overflow-hidden text-center p-4 animate-fade-in">
+      {/* 背景バブル */}
+      {bubbles}
+
+      {/* 共通ヘッダー */}
+      <Header />
+
+      {/* ページごとの内容（children） */}
+      <main className="relative z-10 mt-10">{children}</main>
+    </div>
+  );
+}
+
+export default Layout;

--- a/src/pages/EventList.js
+++ b/src/pages/EventList.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import Layout from '../components/Layout';
+
+function EventList() {
+  return (
+    <Layout>
+      <h2 className="text-3xl font-bold text-green-700 mb-6">開催予定のイベント</h2>
+      <ul className="space-y-4">
+        <li className="bg-white border border-green-200 shadow rounded p-4">
+          🌸 春の花まつり（2025年4月）
+        </li>
+        <li className="bg-white border border-green-200 shadow rounded p-4">
+          🍠 地域の収穫祭（2025年10月）
+        </li>
+        <li className="bg-white border border-green-200 shadow rounded p-4">
+          🎄 クリスマスマーケット（2025年12月）
+        </li>
+      </ul>
+    </Layout>
+  );
+}
+
+export default EventList;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Layout from '../components/Layout';
+
+function Home() {
+  return (
+    <Layout>
+      <div className="flex flex-col items-center justify-center h-[calc(100vh-160px)]">
+        <h2 className="text-4xl md:text-6xl font-bold text-green-700 mb-4">
+          ようこそ、LocalHubへ！
+        </h2>
+        <p className="text-lg md:text-xl text-green-600">
+          地域のイベントを、みんなで見つけて・広げよう
+        </p>
+      </div>
+    </Layout>
+  );
+}
+
+export default Home;


### PR DESCRIPTION
# 実装したこと
- ヘッダーを作成し、ロゴとボタンを実装しました。
- イベント一覧ページを作成し、画面遷移できるようにしました。
- ヘッダーと共通レイアウトを独自のファイルに切り分けてコンポーネント化し、各ファイルを簡素化しました。